### PR TITLE
Search button functionality fixed - state management issue

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -39,9 +39,15 @@ def main():
     st.title("okto")
     st.title("Prayer Times For Today")
     
-    # Initialize session state
+    # Initialize session state variables
     if 'prayer_times' not in st.session_state:
         st.session_state.prayer_times = None
+    if 'location_search' not in st.session_state:
+        st.session_state.location_search = ""
+    if 'calculation_method' not in st.session_state:
+        st.session_state.calculation_method = "Muslim World League"
+    if 'asr_calculation' not in st.session_state:
+        st.session_state.asr_calculation = "Standard"
     
     # Method selection
     col1, col2 = st.columns(2)
@@ -55,7 +61,8 @@ def main():
                 "Egyptian General Authority of Survey",
                 "Umm Al-Qura University, Makkah",
                 "University of Islamic Sciences, Karachi",
-            ]
+            ],
+            key="calculation_method"
         )
     
     with col2:
@@ -64,19 +71,23 @@ def main():
             options=[
                 "Standard",
                 "Hanafi"
-            ]
+            ],
+            key="asr_calculation"
         )
 
     # Location search
     col1, col2 = st.columns([3, 1])
     with col1:
-        location_search = st.text_input("Search for a location (City, Country)")
+        location_search = st.text_input(
+            "Search for a location (City, Country)",
+            key="location_search"
+        )
     with col2:
         st.write("") 
         search_button = st.button("Search")
 
     # Handle search
-    if search_button and location_search:
+    if search_button:
         try:
             method_number = get_calculation_method_number(calculation_method)
             asr_calc = {"Standard": 0, "Hanafi": 1}.get(asr_calculation)


### PR DESCRIPTION
# Issue
The prayer times application required users to click the search button twice to get results. This was happening because Streamlit reruns the entire app script from top to bottom when any widget is interacted with.

In the original code, when users clicked search:
1. First click: Updated the prayer_times in session state but the UI components were already rendered with old values
2. Second click: Finally showed the updated values because the script reran with the updated session state

# Fix
- Added proper session state initialization for all input fields (location_search, calculation_method, asr_calculation)
- Connected input widgets to session state using the `key` parameter
- Streamlined search button logic to use session state values directly

These changes ensure state persistence between app reruns and eliminate the need for double-clicking to see results.

# Technical Details
- Before: Input values were local variables that didn't persist between Streamlit reruns
- After: All inputs are now tied to `st.session_state`, maintaining their values across app refreshes

The key insight was understanding Streamlit's execution model: each user interaction triggers a full script rerun. By properly managing state, we ensure values persist across these reruns.

https://github.com/user-attachments/assets/04aefdc4-478e-49f2-acfc-cb2cf9e69a05

